### PR TITLE
websocket-extensions依存更新とnpm update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2733,15 +2733,15 @@
       }
     },
     "@firebase/analytics": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.5.tgz",
-      "integrity": "sha512-p+h1s9A8EjGWfjAObu8ei46JoN2Ogbtl1RzqW7HjcPuclOIOmPTXKEXXCEXgO79OLxnzzezVeBtHPSx6r6gxJA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.3.6.tgz",
+      "integrity": "sha512-OgBPLsLcYSLBCBLMkuOPnW2YmGo0ruVBtnZ1Yhk0y54oCtrAcm0ijuI98h0evAdA7XfHPgmfKRpke9rU2X9OQQ==",
       "requires": {
         "@firebase/analytics-types": "0.3.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.13",
+        "@firebase/installations": "0.4.11",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.48",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2758,14 +2758,14 @@
       "integrity": "sha512-63vVJ5NIBh/JF8l9LuPrQYSzFimk7zYHySQB4Dk9rVdJ8kV/vGQoVTvRu1UW05sEc2Ug5PqtEChtTHU+9hvPcA=="
     },
     "@firebase/app": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.4.tgz",
-      "integrity": "sha512-E1Zw6yeZYdYYFurMnklKPvE+q/xleHXs7bmcVgyhgAEg3Gv6/qXI4+4GdWh+iF7wmQ3Liesh51xqfdpvHBwAMQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.5.tgz",
+      "integrity": "sha512-rhId5P4egyaVp4HaLsqxV1dJYWbjAyyTnoW8r6t2uXyUGBKUiv+tdK97abkHCo4UQwq/GvUu0Drd96Cm7nEIeA==",
       "requires": {
         "@firebase/app-types": "0.6.1",
-        "@firebase/component": "0.1.12",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.13",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.48",
         "dom-storage": "2.1.0",
         "tslib": "1.11.1",
         "xmlhttprequest": "1.8.0"
@@ -2802,11 +2802,11 @@
       "integrity": "sha512-/+gBHb1O9x/YlG7inXfxff/6X3BPZt4zgBv4kql6HEmdzNQCodIRlEYnI+/da+lN+dha7PjaFH7C7ewMmfV7rw=="
     },
     "@firebase/component": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.12.tgz",
-      "integrity": "sha512-03w800MxR/EW1m7N0Q46WNcngwdDIHDWpFPHTdbZEI6U/HuLks5RJQlBxWqb1P73nYPkN8YP3U8gTdqrDpqY3Q==",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.1.13.tgz",
+      "integrity": "sha512-DuSIM96NQkE3Yo77IOa5BWw8VBdvCR5cbMLNiFT4X3dTU15Dm0zHjncQHt/6rQpABGNYWAfOCJmSU1v6vc3DFA==",
       "requires": {
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -2818,15 +2818,15 @@
       }
     },
     "@firebase/database": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.3.tgz",
-      "integrity": "sha512-gHoCISHQVLoq+rGu+PorYxMkhsjhXov3ocBxz/0uVdznNhrbKkAZaEKF+dIAsUPDlwSYeZuwWuik7xcV3DtRaw==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.6.4.tgz",
+      "integrity": "sha512-m3jaElEEXhr3a9D+M/kbDuRCQG5EmrnSqyEq7iNk3s5ankIrALid0AYm2RZF764F/DIeMFtAzng4EyyEqsaQlQ==",
       "requires": {
         "@firebase/auth-interop-types": "0.1.5",
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.13",
         "@firebase/database-types": "0.5.1",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.48",
         "faye-websocket": "0.11.3",
         "tslib": "1.11.1"
       },
@@ -2855,33 +2855,20 @@
       }
     },
     "@firebase/firestore": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.14.6.tgz",
-      "integrity": "sha512-9TfM4BFQAhyn+gmayX80wZEAO27bUBy471pba/oAYM9UrvPp1US9Bn/QzeuA/hxBSZXcN5zWNcs1Ibyt8eAreg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-1.15.0.tgz",
+      "integrity": "sha512-4eSBDY2hb/og8OEFZSjjzlb0y5+cWpridtQHLYsM4IPcOwxnnlE6RjGWN+UUxgKtvlkvOBdUIlTjL/YYoF+QcA==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/firestore-types": "1.10.3",
-        "@firebase/logger": "0.2.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/component": "0.1.13",
+        "@firebase/firestore-types": "1.11.0",
+        "@firebase/logger": "0.2.5",
+        "@firebase/util": "0.2.48",
         "@firebase/webchannel-wrapper": "0.2.41",
         "@grpc/grpc-js": "0.8.1",
         "@grpc/proto-loader": "^0.5.0",
         "tslib": "1.11.1"
       },
       "dependencies": {
-        "@grpc/grpc-js": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
-          "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
-          "requires": {
-            "semver": "^6.2.0"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
         "tslib": {
           "version": "1.11.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -2890,16 +2877,16 @@
       }
     },
     "@firebase/firestore-types": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.10.3.tgz",
-      "integrity": "sha512-DcYTJbva/gYK3i9q1Jw4tUkuSGQY5tXizSU/yytJgsRZNQrLEbrbHza9n6MAxcBbMSgcWZ24XzCGELtlKgMbSw=="
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-1.11.0.tgz",
+      "integrity": "sha512-hD7+cmMUvT5OJeWVrcRkE87PPuj/0/Wic6bntCopJE1WIX/Dm117AUkHgKd3S7Ici6DLp4bdlx1MjjwWL5942w=="
     },
     "@firebase/functions": {
-      "version": "0.4.44",
-      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.44.tgz",
-      "integrity": "sha512-Nbw+V/jYqfgq7wscsSDidqIzx8TrnmA2wRD1auCFNmf+gSJg8o+gNyCDdNHZI407jvrZcxp3nG1eMbqwmmnp7Q==",
+      "version": "0.4.45",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.4.45.tgz",
+      "integrity": "sha512-Sy0D+52bkabdapTGxPlX+1b2FH+0BEJBmboLfM7EySZV/32oI277pDYKhyp9Pm//eOLspMOpEDvJz1WK8xmQcw==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.13",
         "@firebase/functions-types": "0.3.17",
         "@firebase/messaging-types": "0.4.5",
         "isomorphic-fetch": "2.2.1",
@@ -2919,13 +2906,13 @@
       "integrity": "sha512-DGR4i3VI55KnYk4IxrIw7+VG7Q3gA65azHnZxo98Il8IvYLr2UTBlSh72dTLlDf25NW51HqvJgYJDKvSaAeyHQ=="
     },
     "@firebase/installations": {
-      "version": "0.4.10",
-      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.10.tgz",
-      "integrity": "sha512-Nf7VK9++0eQzjdvBkBNNaOdxPjFiKD0EllLCIQycHozF97BmuFUqb2Ik5L2JaWspWg7vxLNacLHvW48nPGx4Zw==",
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.11.tgz",
+      "integrity": "sha512-ri+8O6vZPF0JKXboMzYFAbN7rn0OeUKLeMuCWdKZGJZD8NS8NRk/YvGRBa+IrkrwBeNNA/bMBUTEnhjN4CdVgQ==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.13",
         "@firebase/installations-types": "0.3.4",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "idb": "3.0.2",
         "tslib": "1.11.1"
       },
@@ -2943,19 +2930,19 @@
       "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q=="
     },
     "@firebase/logger": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.4.tgz",
-      "integrity": "sha512-akHkOU7izYB1okp/B5sxClGjjw6KvZdSHyjNM5pKd67Zg5W6PsbkI/GFNv21+y6LkUkJwDRbdeDgJoYXWT3mMA=="
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.5.tgz",
+      "integrity": "sha512-qqw3m0tWs/qrg7axTZG/QZq24DIMdSY6dGoWuBn08ddq7+GLF5HiqkRj71XznYeUUbfRq5W9C/PSFnN4JxX+WA=="
     },
     "@firebase/messaging": {
-      "version": "0.6.16",
-      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.16.tgz",
-      "integrity": "sha512-TAPISK5y3xbxUw81HxLDP6YPsRryU6Nl8Z7AjNnem13BoN9LJ2/wCi9RDMfPnQhAn0h0N+mpxy/GB+0IlEARlg==",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.6.17.tgz",
+      "integrity": "sha512-wwAn2HrklhBxHpk5UpudJ0wCrlUC9ovFJ88cSOALf82po423IOwR5ijq1z2zKzZiz4D1dLv7rJIqZ0N1MZ/Giw==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
+        "@firebase/component": "0.1.13",
+        "@firebase/installations": "0.4.11",
         "@firebase/messaging-types": "0.4.5",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "idb": "3.0.2",
         "tslib": "1.11.1"
       },
@@ -2973,15 +2960,15 @@
       "integrity": "sha512-sux4fgqr/0KyIxqzHlatI04Ajs5rc3WM+WmtCpxrKP1E5Bke8xu/0M+2oy4lK/sQ7nov9z15n3iltAHCgTRU3Q=="
     },
     "@firebase/performance": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.5.tgz",
-      "integrity": "sha512-FCUxK3IsJuthSosXzCA/B3Lz0o51QLjS1PuHFSxW4zwnMN2p5LrJBof47D2qB/ZYLey8xR4u2IGHOjvSDyKA9w==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.3.6.tgz",
+      "integrity": "sha512-AB+ohBYgF8fe9FacDAcwJaBLRrXgt93no6Pj14xzQ4oX31dQpPrWZdFfNYEUZRU1Gnb/fqWlCaBTObzUXD5cag==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.13",
+        "@firebase/installations": "0.4.11",
+        "@firebase/logger": "0.2.5",
         "@firebase/performance-types": "0.0.13",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -3020,15 +3007,15 @@
       }
     },
     "@firebase/remote-config": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.21.tgz",
-      "integrity": "sha512-EwDNU1mT+8Jn66IUwwNP5SM8AbaI7wmCXjp7djZtTXNrpPoh3xqzSRM1vTgp4Uu/mHffEDfbydsoJAIftADIfQ==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.22.tgz",
+      "integrity": "sha512-xX/b+euI/RP1qAWqNI5YkZ4VFNL00CI7jBJmPzoBbSl1vVglR1ya7u1fbC5SeowxnD1/0QIOYbe5sdnqjmLsyg==",
       "requires": {
-        "@firebase/component": "0.1.12",
-        "@firebase/installations": "0.4.10",
-        "@firebase/logger": "0.2.4",
+        "@firebase/component": "0.1.13",
+        "@firebase/installations": "0.4.11",
+        "@firebase/logger": "0.2.5",
         "@firebase/remote-config-types": "0.1.9",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -3045,13 +3032,13 @@
       "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA=="
     },
     "@firebase/storage": {
-      "version": "0.3.34",
-      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.34.tgz",
-      "integrity": "sha512-vuR1PpGdaCk25D2dT2trfmZZjpdfOn0rPTksvoqg7TAPLeoVsVoDyT2LgF3Arna/jqx52sAIRx1HLrlvzE1pgA==",
+      "version": "0.3.35",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.3.35.tgz",
+      "integrity": "sha512-kS+P5X3lla9bpeWVwmRzJ5atMDPlhLPa8jgutN9vWXWfVnlj82U8VqeAqWc8ndHumHiV0TYLDk9DdGfs6rFL3w==",
       "requires": {
-        "@firebase/component": "0.1.12",
+        "@firebase/component": "0.1.13",
         "@firebase/storage-types": "0.3.12",
-        "@firebase/util": "0.2.47",
+        "@firebase/util": "0.2.48",
         "tslib": "1.11.1"
       },
       "dependencies": {
@@ -3068,9 +3055,9 @@
       "integrity": "sha512-DDV6Fs6aYoGw3w/zZZTkqiipxihnsvHf6znbeZYjIIHit3tr1uLJdGPDPiCTfZcTGPpg2ux6ZmvNDvVgJdHALw=="
     },
     "@firebase/util": {
-      "version": "0.2.47",
-      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.47.tgz",
-      "integrity": "sha512-RjcIvcfswyxYhf0OMXod+qeI/933wl9FGLIszf0/O1yMZ/s8moXcse7xnOpMjmQPRLB9vHzCMoxW5X90kKg/bQ==",
+      "version": "0.2.48",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.48.tgz",
+      "integrity": "sha512-6Wzq6IBF//3mrMTmTQ+JmceM0PMQpxV2GVfXhZn/4sMMkkhB0MA908nPDnatoHwUKyWE3BMw+uTLkyBnkuTu5A==",
       "requires": {
         "tslib": "1.11.1"
       },
@@ -3146,6 +3133,15 @@
         "protobufjs": "^6.8.1"
       },
       "dependencies": {
+        "@grpc/grpc-js": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.5.tgz",
+          "integrity": "sha512-Hm+xOiqAhcpT9RYM8lc15dbQD7aQurM7ZU8ulmulepiPlN7iwBXXwP3vSBUimoFoApRqz7pSIisXU8pZaCB4og==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.2.0"
+          }
+        },
         "arrify": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
@@ -3175,6 +3171,12 @@
             "walkdir": "^0.4.0"
           }
         },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3184,118 +3186,17 @@
       }
     },
     "@grpc/grpc-js": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.0.4.tgz",
-      "integrity": "sha512-Qawt6HUrEmljQMPWnLnIXpcjelmtIAydi3M9awiG02WWJ1CmIvFEx4IOC1EsWUWUlabOGksRbpfvoIeZKFTNXw==",
-      "dev": true,
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-0.8.1.tgz",
+      "integrity": "sha512-e8gSjRZnOUefsR3obOgxG9RtYW2Mw83hh7ogE2ByCdgRhoX0mdnJwBcZOami3E0l643KCTZvORFwfSEi48KFIQ==",
       "requires": {
-        "google-auth-library": "^6.0.0",
         "semver": "^6.2.0"
       },
       "dependencies": {
-        "agent-base": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.0.tgz",
-          "integrity": "sha512-j1Q7cSCqN+AwrmDd+pzgqc0/NpC655x2bUf5ZjRIO77DcNBFmh+OgRNzF6OKdCC9RSCb19fGd99+bhXFdkRNqw==",
-          "dev": true,
-          "requires": {
-            "debug": "4"
-          }
-        },
-        "arrify": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-          "dev": true
-        },
-        "gaxios": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.0.3.tgz",
-          "integrity": "sha512-PkzQludeIFhd535/yucALT/Wxyj/y2zLyrMwPcJmnLHDugmV49NvAi/vb+VUq/eWztATZCNcb8ue+ywPG+oLuw==",
-          "dev": true,
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "extend": "^3.0.2",
-            "https-proxy-agent": "^5.0.0",
-            "is-stream": "^2.0.0",
-            "node-fetch": "^2.3.0"
-          }
-        },
-        "gcp-metadata": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.1.0.tgz",
-          "integrity": "sha512-r57SV28+olVsflPlKyVig3Muo/VDlcsObMtvDGOEtEJXj+DDE8bEl0coIkXh//hbkSDTvo+f5lbihZOndYXQQQ==",
-          "dev": true,
-          "requires": {
-            "gaxios": "^3.0.0",
-            "json-bigint": "^0.3.0"
-          }
-        },
-        "google-auth-library": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.0.0.tgz",
-          "integrity": "sha512-uLydy1t6SHN/EvYUJrtN3GCHFrnJ0c8HJjOxXiGjoTuYHIoCUT3jVxnzmjHwVnSdkfE9Akasm2rM6qG1COTXfQ==",
-          "dev": true,
-          "requires": {
-            "arrify": "^2.0.0",
-            "base64-js": "^1.3.0",
-            "ecdsa-sig-formatter": "^1.0.11",
-            "fast-text-encoding": "^1.0.0",
-            "gaxios": "^3.0.0",
-            "gcp-metadata": "^4.0.0",
-            "gtoken": "^5.0.0",
-            "jws": "^4.0.0",
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "google-p12-pem": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.1.tgz",
-          "integrity": "sha512-VlQgtozgNVVVcYTXS36eQz4PXPt9gIPqLOhHN0QiV6W6h4qSCNVKPtKC5INtJsaHHF2r7+nOIa26MJeJMTaZEQ==",
-          "dev": true,
-          "requires": {
-            "node-forge": "^0.9.0"
-          }
-        },
-        "gtoken": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.1.tgz",
-          "integrity": "sha512-33w4FNDkUcyIOq/TqyC+drnKdI4PdXmWp9lZzssyEQKuvu9ZFN3KttaSnDKo52U3E51oujVGop93mKxmqO8HHg==",
-          "dev": true,
-          "requires": {
-            "gaxios": "^3.0.0",
-            "google-p12-pem": "^3.0.0",
-            "jws": "^4.0.0",
-            "mime": "^2.2.0"
-          }
-        },
-        "https-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
-          "dev": true,
-          "requires": {
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "is-stream": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-          "dev": true
-        },
-        "mime": {
-          "version": "2.4.6",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
-          "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
-          "dev": true
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -3551,9 +3452,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.42.tgz",
-      "integrity": "sha512-R/9QdYFLL9dE9l5cWWzWIZByVGFd7lk7JVOJ7KD+E1SJ4gni7XJRLz9QTjyYQiHIqEAgku9VgxdLjMlhhUaAFg==",
+      "version": "12.12.44",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.44.tgz",
+      "integrity": "sha512-jM6QVv0Sm5d3nW+nUD5jSzPcO6oPqboitSNcwgBay9hifVq/Rauq1PYnROnsmuw45JMBiTnsPAno0bKu2e2xrg==",
       "dev": true
     },
     "@types/q": {
@@ -7687,30 +7588,30 @@
       }
     },
     "firebase": {
-      "version": "7.14.6",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.14.6.tgz",
-      "integrity": "sha512-W7nN57T+slfSYtUoCD7Jup/P+V8velhjbtJUlO4+gYXCG0TT83ah3B+89LlVwOrL3tVAl68GdA892vdXVsY6zQ==",
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-7.15.0.tgz",
+      "integrity": "sha512-0t8w/TT+230/n/XWBw9jGMApCkIEb5K1b+6t4R+SAMOZHMJZvoAwMcwgQXoYeUBFOJOQpgDhIZK8PzApq4iUXw==",
       "requires": {
-        "@firebase/analytics": "0.3.5",
-        "@firebase/app": "0.6.4",
+        "@firebase/analytics": "0.3.6",
+        "@firebase/app": "0.6.5",
         "@firebase/app-types": "0.6.1",
         "@firebase/auth": "0.14.6",
-        "@firebase/database": "0.6.3",
-        "@firebase/firestore": "1.14.6",
-        "@firebase/functions": "0.4.44",
-        "@firebase/installations": "0.4.10",
-        "@firebase/messaging": "0.6.16",
-        "@firebase/performance": "0.3.5",
+        "@firebase/database": "0.6.4",
+        "@firebase/firestore": "1.15.0",
+        "@firebase/functions": "0.4.45",
+        "@firebase/installations": "0.4.11",
+        "@firebase/messaging": "0.6.17",
+        "@firebase/performance": "0.3.6",
         "@firebase/polyfill": "0.3.36",
-        "@firebase/remote-config": "0.1.21",
-        "@firebase/storage": "0.3.34",
-        "@firebase/util": "0.2.47"
+        "@firebase/remote-config": "0.1.22",
+        "@firebase/storage": "0.3.35",
+        "@firebase/util": "0.2.48"
       }
     },
     "firebase-tools": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-8.4.1.tgz",
-      "integrity": "sha512-kiC5KXQdQ2ksRRJEZ5dXsLHRPGwR5Y1nEpTtJly91cs7mASIi4tzpVnX5pF1WXZsa323jXkY9elNUPw7fWvvog==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-8.4.2.tgz",
+      "integrity": "sha512-Kk3MKpM8+fZf1p+KzXBq1UDZxWBy+MWR6RFvj8L1xgoabsESMGbTgamJZfM1IWU3JJQFDH1fF8aPI5CvwXTr/A==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^1.7.0",
@@ -8303,6 +8204,12 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
         }
       }
     },
@@ -8502,6 +8409,12 @@
           "requires": {
             "semver": "^6.2.0"
           }
+        },
+        "node-fetch": {
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
+          "dev": true
         },
         "semver": {
           "version": "6.3.0",
@@ -9647,17 +9560,6 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "1.7.3",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-          "requires": {
-            "encoding": "^0.1.11",
-            "is-stream": "^1.0.1"
-          }
-        }
       }
     },
     "isstream": {
@@ -11380,10 +11282,13 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
-      "dev": true
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "requires": {
+        "encoding": "^0.1.11",
+        "is-stream": "^1.0.1"
+      }
     },
     "node-fetch-npm": {
       "version": "2.0.4",
@@ -13185,9 +13090,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "13.13.6",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.6.tgz",
-          "integrity": "sha512-zqRj8ugfROCjXCNbmPBe2mmQ0fJWP9lQaN519hwunOgpHgVykme4G6FW95++dyNFDvJUk4rtExkVkL0eciu5NA=="
+          "version": "13.13.10",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.10.tgz",
+          "integrity": "sha512-J+FbkhLTcFstD7E5mVZDjYxa1VppwT2HALE6H3n2AnBSP8uiCQk0Pyr6BkJcP38dFV9WecoVJRJmFnl9ikIW7Q=="
         }
       }
     },
@@ -17425,9 +17330,9 @@
       }
     },
     "websocket-extensions": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg=="
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "whatwg-fetch": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "@angular/platform-browser": "^9.1.9",
     "@angular/platform-browser-dynamic": "^9.1.9",
     "@angular/router": "^9.1.9",
-    "firebase": "^7.14.6",
+    "firebase": "^7.15.0",
     "rxjs": "~6.5.4",
     "tslib": "^1.10.0",
+    "websocket-extensions": ">=0.1.4",
     "zone.js": "~0.10.2"
   },
   "devDependencies": {
@@ -35,9 +36,9 @@
     "@angular/language-service": "^9.1.9",
     "@types/jasmine": "~3.5.0",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^12.12.42",
+    "@types/node": "^12.12.44",
     "codelyzer": "^5.1.2",
-    "firebase-tools": "^8.4.1",
+    "firebase-tools": "^8.4.2",
     "fuzzy": "^0.1.3",
     "inquirer": "^6.2.2",
     "inquirer-autocomplete-prompt": "^1.0.1",


### PR DESCRIPTION
- Dependabotのsecurity alertsを誤ってcloseしてしまったため、依存更新しなければならないと思ってpackage.jsonにwebsocket-extensionsのバージョンを記述しました
- ついでにangularとfirebaseを最新版にした方がいいかなという安直な考えでnpm updateしましたが、逆に依存関係や不具合出るリスクもあるのに余計なことしてしまったかなと今思いました…