### PR TITLE
ヘッダーをレスポンシブ対応、ログインUI、他マークアップ

### DIFF
--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -1,5 +1,5 @@
 .footer {
-  border-top: 1px solid rgba(0, 0, 0, 0.12);
+  background-color: #f5f5f5;
   padding: 16px;
   &__nav {
     display: flex;

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,24 +1,25 @@
-<mat-toolbar color="primary" class="header">
+<mat-toolbar class="header">
   <mat-toolbar-row class="header__container">
     <a routerLink="/" class="header__title">DTMPlace</a>
     <form class="search">
       <input matInput placeholder="キーワードを入力" class="search__input" autocomplete="off" />
-      <button mat-icon-button color="white" aria-label="icon button with a search icon" class="search__button">
+      <button mat-icon-button color="white" aria-label="検索アイコン" class="search__button">
         <mat-icon>search</mat-icon>
       </button>
     </form>
 
-
     <ng-template #default>
       <button (click)="login()" mat-flat-button color="primary" medium class="login-button">
-        Twitterでログイン
+        <mat-icon>login</mat-icon>
+        <span>Twitterでログイン</span>
       </button>
     </ng-template>
 
     <div class="header__nav">
       <ng-container *ngIf="user$ | async as user; else default">
         <button mat-flat-button color="primary" medium class="post-button">
-          投稿する
+          <mat-icon>post_add</mat-icon>
+          <span> 投稿する</span>
         </button>
 
         <button mat-icon-button medium [matMenuTriggerFor]="menu" aria-label="マイメニュー"

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -9,17 +9,16 @@
     </form>
 
     <ng-template #default>
-      <button (click)="login()" mat-flat-button color="primary" medium class="login-button">
-        <mat-icon>login</mat-icon>
+      <button [disabled]="isProcessing" (click)="login()" mat-flat-button color="primary" medium class="login-button">
         <span>Twitterでログイン</span>
       </button>
     </ng-template>
 
-    <div class="header__nav">
-      <ng-container *ngIf="user$ | async as user; else default">
+    <ng-container *ngIf="user$ | async as user; else default">
+      <div class="header__nav">
         <button mat-flat-button color="primary" medium class="post-button">
           <mat-icon>post_add</mat-icon>
-          <span> 投稿する</span>
+          <span>投稿する</span>
         </button>
 
         <button mat-icon-button medium [matMenuTriggerFor]="menu" aria-label="マイメニュー"
@@ -41,8 +40,7 @@
             <span>ログアウト</span>
           </button>
         </mat-menu>
-      </ng-container>
-
-    </div>
+      </div>
+    </ng-container>
   </mat-toolbar-row>
 </mat-toolbar>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -13,7 +13,7 @@
     margin: 0 auto;
   }
   &__title {
-    color: white;
+    color: #ffffff;
     font-weight: bold;
     font-size: 24px;
     text-decoration: none;
@@ -26,8 +26,7 @@
 .search {
   display: block;
   position: relative;
-  max-width: 640px;
-  min-width: 110px;
+  min-width: 114px;
   flex: 1;
   padding: 0 24px;
   &__input {
@@ -52,7 +51,11 @@
 }
 
 .login-button {
-  background-color: #ff5500;
+  background-color: #1da1f2;
+}
+
+.login-button:disabled {
+  display: none;
 }
 
 .post-button {

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -1,20 +1,22 @@
 .header {
-  background-color: #262d30;
+  background-color: #424242;
+  position: fixed;
+  z-index: 1;
   margin: 0;
   display: flex;
   height: 70px;
   &__container {
+    max-width: 1000px;
     height: 100%;
+    flex-wrap: wrap;
     justify-content: space-between;
+    margin: 0 auto;
   }
   &__title {
+    color: white;
+    font-weight: bold;
     font-size: 24px;
     text-decoration: none;
-    &:active,
-    &:visited,
-    &:hover {
-      color: white;
-    }
   }
   &__nav {
     display: flex;
@@ -25,6 +27,7 @@
   display: block;
   position: relative;
   max-width: 640px;
+  min-width: 110px;
   flex: 1;
   padding: 0 24px;
   &__input {
@@ -39,19 +42,42 @@
     font-size: 12px;
     margin: 0;
     outline: none;
-    border: none;
+    border: solid 2px #f3f3f3;
   }
   &__button {
     position: absolute;
-    color: black;
+    color: #757575;
     right: 24px;
   }
 }
 
+.login-button {
+  background-color: #ff5500;
+}
+
 .post-button {
+  background-color: #ff5500;
   margin-right: 24px;
 }
 
 .my-menu {
   background-size: cover;
+  border: solid 1px #f3f3f3;
+}
+
+@media screen and (max-width: 480px) {
+  .header {
+    height: 110px;
+  }
+  .search {
+    order: 1;
+  }
+}
+
+@media screen and (max-width: 350px) {
+  .post-button {
+    span {
+      display: none;
+    }
+  }
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
+import { take } from 'rxjs/operators';
 
 @Component({
   selector: 'app-header',
@@ -8,9 +9,15 @@ import { AuthService } from '../services/auth.service';
 })
 export class HeaderComponent implements OnInit {
   user$ = this.authService.afUser$;
+  isProcessing = true;
+
   constructor(
     private authService: AuthService
-  ) { }
+  ) {
+    this.user$.pipe(take(1)).subscribe(() => {
+      this.isProcessing = false;
+    });
+  }
 
   ngOnInit(): void {
   }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -17,6 +17,12 @@ img {
   max-width: 100%;
 }
 .container {
-  padding: 16px;
-  background-color: #f6f6f4;
+  padding: 86px 16px 16px 16px;
+  background-color: #f5f5f5;
+}
+
+@media screen and (max-width: 480px) {
+  .container {
+    padding: 126px 16px 16px 16px;
+  }
 }


### PR DESCRIPTION
fix #15 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![header_res](https://user-images.githubusercontent.com/37304826/84791540-b5e63000-b02d-11ea-9137-74dd3fa19869.gif)

## 作業概要

- [x] ヘッダーを固定、レスポンシブ対応と色変更
- [x] フッターの色変更
- [x] Containerをヘッダー分下げる
- [x] ログイン中のUIとマークアップ
