### PR TITLE
Firestoreから記事一覧を表示、ホーム画面スタイル調整

### DIFF
--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -3,10 +3,10 @@ import { CommonModule } from '@angular/common';
 
 import { HomeRoutingModule } from './home-routing.module';
 import { HomeComponent } from './home/home.component';
-import { MatButtonModule } from '@angular/material/button';
+import { MatTabsModule } from '@angular/material/tabs';
 import { SharedModule } from '../shared/shared.module';
 @NgModule({
   declarations: [HomeComponent],
-  imports: [CommonModule, HomeRoutingModule, MatButtonModule, SharedModule],
+  imports: [CommonModule, HomeRoutingModule, MatTabsModule, SharedModule],
 })
-export class HomeModule {}
+export class HomeModule { }

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -1,11 +1,16 @@
 <div class="container">
-  <div class="home-menu">
-    <button mat-button class="home-menu__item" large>人気記事</button>
-    <button mat-button class="home-menu__item" large>新着記事</button>
-  </div>
-  <div class="home-main">
-    <ng-container *ngFor="let article of articles$ | async">
-      <app-article *ngIf="article" [article]="article"></app-article>
-    </ng-container>
+  <div class="home-page">
+    <div class="home-main">
+      <h3 class="home-main__title">トレンド</h3>
+      <ng-container *ngFor="let article of articles$ | async">
+        <app-article *ngIf="article" [article]="article"></app-article>
+      </ng-container>
+    </div>
+    <div class="home-sub">
+      <h3 class="home-main__title">最新の記事</h3>
+      <ng-container *ngFor="let article of articles$ | async">
+        <app-article *ngIf="article" [article]="article"></app-article>
+      </ng-container>
+    </div>
   </div>
 </div>

--- a/src/app/home/home/home.component.html
+++ b/src/app/home/home/home.component.html
@@ -4,9 +4,8 @@
     <button mat-button class="home-menu__item" large>新着記事</button>
   </div>
   <div class="home-main">
-    <app-article
-      *ngFor="let article of articles"
-      [article]="article"
-    ></app-article>
+    <ng-container *ngFor="let article of articles$ | async">
+      <app-article *ngIf="article" [article]="article"></app-article>
+    </ng-container>
   </div>
 </div>

--- a/src/app/home/home/home.component.scss
+++ b/src/app/home/home/home.component.scss
@@ -1,20 +1,31 @@
-.home-menu {
-  display: flex;
-  justify-content: space-around;
-  max-width: 400px;
+.home-page {
+  max-width: 950px;
   margin: 0 auto;
-  &__item {
-    width: 100%;
-    text-align: center;
-    font-size: 16px;
-    border: 1px solid rgba(0, 0, 0, 0.12);
-    background-color: #ffffff;
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+.home-main {
+  max-width: 610px;
+  margin: 0 auto;
+  &__title {
+    color: #424242;
+    font-size: 20px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid #424242;
+  }
+}
+.home-sub {
+  max-width: 290px;
+  padding-left: 8px;
+  margin: 0 auto;
+  &__title {
+    color: #424242;
   }
 }
 
-.home-main {
-  display: flex;
-  flex-direction: column;
-  max-width: 800px;
-  margin: 0 auto;
+@media screen and (max-width: 940px) {
+  .home-sub {
+    max-width: 610px;
+  }
 }

--- a/src/app/home/home/home.component.ts
+++ b/src/app/home/home/home.component.ts
@@ -1,5 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Article } from 'src/app/interfaces/article';
+import { ArticleService } from 'src/app/services/article.service';
+import { Observable } from 'rxjs';
 
 @Component({
   selector: 'app-home',
@@ -7,40 +9,9 @@ import { Article } from 'src/app/interfaces/article';
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  articles: Article[] = [
-    {
-      userId: 'u00001',
-      id: 'a00001',
-      thumbnailUrl: 'https://placehold.it/80x80',
-      title: 'Sylenth1の音作り',
-      tag: 'Sylenth1',
-      text: 'Sylenth1はLennarDigital社から発売されているソフトシンセ音源で',
-    },
-    {
-      userId: 'u00002',
-      id: 'a00002',
-      thumbnailUrl: 'https://placehold.it/80x80',
-      title: 'Nexus3の個人的使い方',
-      tag: 'Nexus3',
-      text: 'Nexus3はreFX社から発売されているサンプラーベースの音源で',
-    },
-    {
-      userId: 'u00001',
-      id: 'a00003',
-      thumbnailUrl: 'https://placehold.it/80x80',
-      title: 'DTM00001',
-      tag: 'Sylenth1',
-      text: '使い方はこの通り',
-    },
-    {
-      userId: 'u00003',
-      id: 'a00004',
-      thumbnailUrl: 'https://placehold.it/80x80',
-      title: 'DTM00002',
-      tag: 'Sylenth1',
-      text: '使い方はこの通り',
-    },
-  ];
-  constructor() {}
-  ngOnInit(): void {}
+  articles$: Observable<Article[]> = this.articleService.getArticle();
+  constructor(
+    private articleService: ArticleService,
+  ) { }
+  ngOnInit(): void { }
 }

--- a/src/app/notes/create/create.component.ts
+++ b/src/app/notes/create/create.component.ts
@@ -36,7 +36,7 @@ export class CreateComponent implements OnInit {
     this.articleService.createArticle({
       userId: this.authService.uid,
       id: 'n00001',
-      thumbnailUrl: 'imageUrl',
+      thumbnailUrl: 'http://placekitten.com/100/100',
       title: formData.title,
       tag: 'DTM',
       text: formData.text,

--- a/src/app/services/article.service.ts
+++ b/src/app/services/article.service.ts
@@ -3,6 +3,8 @@ import { AngularFirestore } from '@angular/fire/firestore';
 import { Article } from '../interfaces/article';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { Router } from '@angular/router';
+import { map } from 'rxjs/operators';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
@@ -23,5 +25,9 @@ export class ArticleService {
           duration: 2000,
         });
       });
+  }
+
+  getArticle() {
+    return this.db.collection<Article>(`articles`).valueChanges();
   }
 }

--- a/src/app/shared/article/article.component.html
+++ b/src/app/shared/article/article.component.html
@@ -1,13 +1,15 @@
 <mat-card class="card">
-  <div class="card__icon">
-    <img [src]="article.thumbnailUrl" alt="アイコン" />
-  </div>
-  <div class="card__right">
+  <img mat-card-image class="card__eye-catch" [src]="article.thumbnailUrl" alt="アイコン" />
+  <mat-card-content class="card__content">
     <a class="card__title">
       {{ article.title }}
     </a>
     <p class="card__text">
       {{ article.text }}
     </p>
-  </div>
+    <div class="card__author">
+      <a mat-card-avatar class="card__user-icon"></a>
+      <a class="card__user-name">こむら</a>
+    </div>
+  </mat-card-content>
 </mat-card>

--- a/src/app/shared/article/article.component.scss
+++ b/src/app/shared/article/article.component.scss
@@ -1,22 +1,30 @@
 .card {
-  display: flex;
-  align-items: center;
-  padding: 16px;
-  margin: 4px 0;
-  &__icon {
-    min-width: 80px;
-    margin-right: 16px;
+  max-width: 610px;
+  padding: 16px 0 0 0;
+  margin-bottom: 30px;
+  &__eye-catch {
+    max-height: 300px;
+    margin: 0;
   }
-  &__right {
-    height: 100px;
+  &__content {
+    padding: 16px;
   }
   &__title {
     font-size: 20px;
     font-weight: bold;
   }
-  &__text {
-    max-height: 44px;
+  &__author {
     margin: 0;
-    overflow: hidden;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  &__user-icon {
+    background-image: url("https://pbs.twimg.com/profile_images/1020302875229007872/nvfnS9YM_normal.jpg");
+    background-size: cover;
+  }
+  &__user-name {
+    font-size: 16px;
+    padding: 8px;
   }
 }

--- a/src/app/shared/article/article.component.ts
+++ b/src/app/shared/article/article.component.ts
@@ -9,7 +9,7 @@ import { Article } from 'src/app/interfaces/article';
 export class ArticleComponent implements OnInit {
   @Input() article: Article;
 
-  constructor() {}
+  constructor() { }
 
-  ngOnInit(): void {}
+  ngOnInit(): void { }
 }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -2,10 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ArticleComponent } from './article/article.component';
 import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
 
 @NgModule({
   declarations: [ArticleComponent],
-  imports: [CommonModule, MatCardModule],
+  imports: [CommonModule, MatCardModule, MatButtonModule],
   exports: [ArticleComponent],
 })
-export class SharedModule {}
+export class SharedModule { }


### PR DESCRIPTION
fix #62 

## セルフチェック

- [x] 開発途中のコメントアウトが残っていない
- [x] 関係ない差分が含まれていない
- [x] 競合していない

## 実装イメージ

![image](https://user-images.githubusercontent.com/37304826/85174929-5dbf6000-b2b1-11ea-9e70-65f3f2435f75.png)

## 作業概要

- firestoreから単純にデータを取得して表示
- ホーム画面のマークアップを悩みながら組む

よろしくお願いいたします。